### PR TITLE
add publish-unstable workflow

### DIFF
--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -1,0 +1,41 @@
+# For every push to the master branch, this publishes an NPM package to the
+# "unstable" NPM tag.
+
+name: Publish Unstable
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  publish:
+    name: "NPM Publish"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: yarn
+          # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      # We need a workspace aware version of npm because our addon is in a subdir but our .npmrc is in the root
+      - name: npm8
+        run: npm install -g npm@8
+
+      - name: set version
+        run: npm version --no-git-tag-version --workspaces-update=false `node -e "console.log(require('./package.json').version)"`-unstable.`git rev-parse --short HEAD`
+        working-directory: ember-async-data
+
+      - name: npm publish
+        run: npm publish --tag=unstable --verbose --workspace=ember-async-data
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
@chriskrycho would you mind to add `NODE_AUTH_TOKEN` to config to allow such automation?  (I don't have permission)

this will allow folks to use latest changes from `master` as it's not possible to point to branch anymore because it's a monorepo now (which is possible with v1 addons today).

we have similar automation in `ember-modifiers` already