### PR TITLE
Drop TypeScript support for <= 4.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,11 +96,6 @@ jobs:
       fail-fast: false
       matrix:
         ts-version:
-          - 4.3
-          - 4.4
-          - 4.5
-          - 4.6
-          - 4.7
           - 4.8
           - 4.9
           - next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         ts-version:
+          - 4.7
           - 4.8
           - 4.9
           - next

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
   <a href='https://www.npmjs.com/package/ember-async-data'>
     <img src='https://img.shields.io/npm/v/ember-async-data.svg' alt='npm'>
   </a>
-  <a href='https://github.com/tracked-tools/ember-async-data/blob/main/.github/workflows/CI.yml#L61'>
-    <img src='https://img.shields.io/badge/TypeScript-4.3%20%7C%204.4%20%7C%204.5%20%7C%204.6%20%7C%204.7%20%7C%204.8%20%7C%204.9%20%7C%20next-3178c6' alt='supported TypeScript versions'>
+  <a href='https://github.com/tracked-tools/ember-async-data/blob/main/.github/workflows/CI.yml#L98'>
+    <img src='https://img.shields.io/badge/TypeScript-4.8%20%7C%204.9%20%7C%20next-3178c6' alt='supported TypeScript versions'>
   </a>
   <a href='https://github.com/tracked-tools/ember-async-data/blob/main/.github/workflows/Nightly.yml'>
     <img src='https://github.com/tracked-tools/ember-async-data/workflows/Nightly%20TypeScript%20Run/badge.svg' alt='Nightly TypeScript Run'>


### PR DESCRIPTION
Note sure how what we should consider "old" TypeScript versions.

couldn't get advise in https://rfcs.emberjs.com/id/0724-road-to-typescript/#semantic-versioning-and-supported-typescript-versions either