### PR TITLE
Add hard error and deprecations for 1.0

### DIFF
--- a/ember-async-data/src/tracked-async-data.ts
+++ b/ember-async-data/src/tracked-async-data.ts
@@ -63,11 +63,12 @@ class _TrackedAsyncData<T> {
       parameter, and you have a test failure which causes async code to not get
       cleaned up you may see all following tests fail.
    */
-  constructor(data: T | Promise<T>, context: {}) {
-    assert(
-      'You must pass a destroyable object as the context for TrackedAsyncData',
-      !!context
-    );
+  constructor(data: T | Promise<T>, context: object) {
+    if (typeof context !== 'object' || context == null) {
+      throw new Error(
+        'You must pass a destroyable object as the context for TrackedAsyncData'
+      );
+    }
 
     if (this.constructor !== _TrackedAsyncData) {
       throw new Error('tracked-async-data cannot be subclassed');

--- a/ember-async-data/src/tracked-async-data.ts
+++ b/ember-async-data/src/tracked-async-data.ts
@@ -1,6 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import { dependentKeyCompat } from '@ember/object/compat';
-import { assert, warn } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { buildWaiter } from '@ember/test-waiters';
 import {
   associateDestroyableChild,
@@ -146,10 +146,18 @@ class _TrackedAsyncData<T> {
    */
   @dependentKeyCompat
   get value(): T | null {
-    warn(
+    deprecate(
       "Accessing `value` when TrackedAsyncData is not in the resolved state is not supported and will throw an error in the future. Always check that `.state` is `'RESOLVED'` or that `.isResolved` is `true` before accessing this property.",
       this.#state.data[0] === 'RESOLVED',
-      { id: 'tracked-async-data::invalid-value-access' }
+      {
+        id: 'tracked-async-data::invalid-value-access',
+        for: 'ember-async-data',
+        since: {
+          available: '1.0.0',
+          enabled: '1.0.0',
+        },
+        until: '2.0.0',
+      }
     );
 
     return this.#state.data[0] === 'RESOLVED' ? this.#state.data[1] : null;
@@ -167,10 +175,18 @@ class _TrackedAsyncData<T> {
    */
   @dependentKeyCompat
   get error(): unknown {
-    warn(
+    deprecate(
       "Accessing `error` when TrackedAsyncData is not in the rejected state is not supported and will throw an error in the future. Always check that `.state` is `'REJECTED'` or that `.isRejected` is `true` before accessing this property.",
       this.#state.data[0] === 'REJECTED',
-      { id: 'tracked-async-data::invalid-error-access' }
+      {
+        id: 'tracked-async-data::invalid-error-access',
+        for: 'ember-async-data',
+        since: {
+          available: '1.0.0',
+          enabled: '1.0.0',
+        },
+        until: '2.0.0',
+      }
     );
 
     return this.#state.data[0] === 'REJECTED' ? this.#state.data[1] : null;


### PR DESCRIPTION
- Make missing context a hard error in all contexts (not just `assert` for development).
- Make the invalid state checks (looking up `.value` when not `.isResolved` etc.) deprecations, so people can use deprecation workflow to burn them down over time before doing the 2.0 upgrade.