### PR TITLE
Use `16 || >= 18` in test app engines

### DIFF
--- a/test-app/package.json
+++ b/test-app/package.json
@@ -70,7 +70,7 @@
     "webpack": "^5.76.1"
   },
   "engines": {
-    "node": ">= 18"
+    "node": "16 || >= 18"
   },
   "volta": {
     "extends": "../package.json"


### PR DESCRIPTION
Since v16 remains in service until September, we will keep it here, but it does not affect end users, *only* the test app. We just want to make sure it does not *break* if/as other deps require v16.