### PR TITLE
Bugfix: drop `context` and stop caching `TrackedAsyncData`

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ export default class Profile extends Component<{ userId: string }> {
   @service store: Store;
 
   get fullProfile() {
-    return new TrackedAsyncData(this.store.findRecord('user', userId), this);
+    return new TrackedAsyncData(this.store.findRecord('user', userId));
   }
 }
 ```
@@ -334,7 +334,7 @@ export default class SmartProfile extends Component {
 
   @cached
   get someData() {
-    return load(this.store.findRecord('user', this.args.id), this);
+    return load(this.store.findRecord('user', this.args.id));
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ The public API for `TrackedAsyncData`:
 
 ```ts
 class TrackedAsyncData<T> {
-  constructor(data: T | Promise<T>, context?: object);
+  constructor(data: T | Promise<T>);
 
   get state(): "PENDING" | "RESOLVED" | "REJECTED";
   get isPending(): boolean;
@@ -632,7 +632,6 @@ class TrackedAsyncData<T> {
 #### Notes
 
 - `value` is `T | null` today, but only for the sake of safe interop with Ember Classic computed properties (which eagerly evaluate getters for the sake of). You *should not* rely on the `null` fallback, as accessing `value` when `isResolved` is false will become a hard error at the 1.0 release. The same is true of `error`.
-- The `context` argument is currently optional but will become mandatory at the 1.0 release. This allows the type to be torn down correctly as part of Ember's "destroyables" API.
 - The class is *not* intended for subclassing, and will in fact throw in the constructor if you try to subclass it!
 - The `value` and `error` getters will *warn* if you access them and the underlying promise is in the wrong state. In the future, this will be converted to throwing an error. (It currently only warns because classic computed properties actively lookup and cache the values returned from their dependent keys.)
 
@@ -642,7 +641,7 @@ class TrackedAsyncData<T> {
 The `load` helper function is basically just a static constructor for `TrackedAsyncData`:
 
 ```ts
-function load<T>(data: T | Promise<T>, context?: object): TrackedAsyncData<T>;
+function load<T>(data: T | Promise<T>): TrackedAsyncData<T>;
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ This code would invoke the getter twice on first render, which would therefore t
 This is the *correct* default behavior, even though it might be surprising at first:
 
 - For getters and templates: in Octane, caching is something we layer onto getters where it makes sense to pay for them, rather than paying for them *everywhere* (as in Ember classic) even when that's far more costly than just rerunning the getter a couple times. For API calls, it always makes sense!
-- For the `TrackedAsyncData` API, this similarly means we don't pay for extra caching of arguments in the many cases we don't need it. (We *do* guarantee we only ever have a single `TrackedAsyncData` per `Promise`, as described elsewhere in the docs, so we don't pay *more* than we need to.)
+- For the `TrackedAsyncData` API, this similarly means we don't pay for extra caching of arguments in the many cases we don't need it.
 
 _**Note:** in the future, we will make a set of [Resources](https://www.pzuraq.com/introducing-use/) layered on top of the core data types here, which will allow us to build in caching for API calls._
 

--- a/ember-async-data/src/helpers/load.ts
+++ b/ember-async-data/src/helpers/load.ts
@@ -1,4 +1,4 @@
-import Helper from '@ember/component/helper';
+import { helper } from '@ember/component/helper';
 import TrackedAsyncData from '../tracked-async-data';
 
 /**
@@ -63,15 +63,16 @@ import TrackedAsyncData from '../tracked-async-data';
   @note Prefer to use `TrackedAsyncData` directly! This function is provided
     simply for symmetry with the helper and backwards compatibility.
  */
-export function load<T>(
-  data: T | Promise<T>,
-  context: {}
-): TrackedAsyncData<T> {
-  return new TrackedAsyncData(data, context);
+export function load<T>(data: T | Promise<T>): TrackedAsyncData<T> {
+  return new TrackedAsyncData(data);
 }
 
-export default class Load<T> extends Helper {
-  compute([data]: [T | Promise<T>]): TrackedAsyncData<T> {
-    return new TrackedAsyncData(data, this);
-  }
-}
+// TODO: in v2.0.0, switch this to simply using the function above. (It needs to
+// be in a breaking change because of the change in the call signature.)
+const loadHelper = helper(function loadHelper<T>([data]: [
+  T | Promise<T>
+]): TrackedAsyncData<T> {
+  return new TrackedAsyncData(data);
+});
+
+export default loadHelper;

--- a/ember-async-data/src/tracked-async-data.ts
+++ b/ember-async-data/src/tracked-async-data.ts
@@ -298,8 +298,7 @@ interface Rejected<T> extends _TrackedAsyncData<T> {
  */
 type TrackedAsyncData<T> = Pending<T> | Resolved<T> | Rejected<T>;
 const TrackedAsyncData = _TrackedAsyncData as new <T>(
-  data: T | Promise<T>,
-  context: {}
+  data: T | Promise<T>
 ) => TrackedAsyncData<T>;
 export default TrackedAsyncData;
 

--- a/ember-async-data/type-tests/load-test.ts
+++ b/ember-async-data/type-tests/load-test.ts
@@ -1,16 +1,23 @@
-import Helper from '@ember/component/helper';
 import TrackedAsyncData from '../src/tracked-async-data';
-import Load, { load } from '../src/helpers/load';
+import loadHelper, { load } from '../src/helpers/load';
 import { expectTypeOf } from 'expect-type';
+import {
+  EmptyObject,
+  FunctionBasedHelperInstance,
+} from '@ember/component/helper';
 
 expectTypeOf(load).toEqualTypeOf<
-  <T>(data: T | Promise<T>, context: {}) => TrackedAsyncData<T>
+  <T>(data: T | Promise<T>) => TrackedAsyncData<T>
 >();
 
-expectTypeOf(load(true, {})).toEqualTypeOf(new TrackedAsyncData(true, {}));
+expectTypeOf(load(true)).toEqualTypeOf(new TrackedAsyncData(true));
 
-interface PublicAPIForHelper<T> extends Helper {
-  compute([data]: [T | Promise<T>]): TrackedAsyncData<T>;
-}
+type LoadHelper = abstract new <T>() => FunctionBasedHelperInstance<{
+  Args: {
+    Positional: [T | Promise<T>];
+    Named: EmptyObject;
+  };
+  Return: TrackedAsyncData<T>;
+}>;
 
-expectTypeOf<Load<string>>().toEqualTypeOf<PublicAPIForHelper<string>>();
+expectTypeOf(loadHelper).toEqualTypeOf<LoadHelper>();

--- a/ember-async-data/type-tests/tracked-async-data-test.ts
+++ b/ember-async-data/type-tests/tracked-async-data-test.ts
@@ -20,17 +20,17 @@ declare class PublicAPI<T> {
   toString(): string;
 }
 
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(12, {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith('hello', {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(true, {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(null, {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(undefined, {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith({ cool: 'story' }, {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(['neat'], {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve(), {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve(12), {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject(), {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject('gah'), {});
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(12);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith('hello');
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(true);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(null);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(undefined);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith({ cool: 'story' });
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(['neat']);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve());
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve(12));
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject());
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject('gah'));
 
 // We use `toMatchTypeOf` here to confirm the union type which makes up
 // `TrackedAsyncData` is structurally compatible with the desired public

--- a/test-app/tests/unit/helpers/load-test.ts
+++ b/test-app/tests/unit/helpers/load-test.ts
@@ -18,7 +18,7 @@ module.skip('Unit | load', function (hooks) {
 
   test('given a promise', async function (assert) {
     const { promise, resolve } = defer();
-    const result = load(promise, this);
+    const result = load(promise);
     assert.ok(
       result instanceof TrackedAsyncData,
       'it returns a TrackedAsyncData instance'
@@ -28,7 +28,7 @@ module.skip('Unit | load', function (hooks) {
   });
 
   test('given a plain value', async function (assert) {
-    const result = load(12, this);
+    const result = load(12);
     assert.ok(
       result instanceof TrackedAsyncData,
       'it returns a TrackedAsyncData instance'

--- a/test-app/tests/unit/tracked-async-data-test.ts
+++ b/test-app/tests/unit/tracked-async-data-test.ts
@@ -9,14 +9,14 @@ module('Unit | TrackedAsyncData', function () {
     //   this fails both at the type-checking level and dynamically at runtime.
     class Subclass extends TrackedAsyncData<unknown> {}
 
-    assert.throws(() => new Subclass(Promise.resolve('nope'), this));
+    assert.throws(() => new Subclass(Promise.resolve('nope')));
   });
 
   test('is initially PENDING', async function (assert) {
     assert.expect(6);
     const deferred = defer();
 
-    const result = new TrackedAsyncData(deferred.promise, this);
+    const result = new TrackedAsyncData(deferred.promise);
     assert.strictEqual(result.state, 'PENDING');
     assert.true(result.isPending);
     assert.false(result.isResolved);
@@ -32,7 +32,7 @@ module('Unit | TrackedAsyncData', function () {
     assert.expect(6);
 
     const deferred = defer();
-    const result = new TrackedAsyncData(deferred.promise, this);
+    const result = new TrackedAsyncData(deferred.promise);
 
     deferred.resolve('foobar');
     await settled();
@@ -49,7 +49,7 @@ module('Unit | TrackedAsyncData', function () {
     test('undefined', async function (assert) {
       assert.expect(6);
 
-      const loadUndefined = new TrackedAsyncData(undefined, this);
+      const loadUndefined = new TrackedAsyncData(undefined);
       await settled();
 
       assert.strictEqual(loadUndefined.state, 'RESOLVED');
@@ -63,7 +63,7 @@ module('Unit | TrackedAsyncData', function () {
     test('null', async function (assert) {
       assert.expect(6);
 
-      const loadNull = new TrackedAsyncData(null, this);
+      const loadNull = new TrackedAsyncData(null);
       await settled();
 
       assert.strictEqual(loadNull.state, 'RESOLVED');
@@ -78,7 +78,7 @@ module('Unit | TrackedAsyncData', function () {
       assert.expect(6);
 
       const notAThenableObject = { notAThenable: true };
-      const loadObject = new TrackedAsyncData(notAThenableObject, this);
+      const loadObject = new TrackedAsyncData(notAThenableObject);
       await settled();
 
       assert.strictEqual(loadObject.state, 'RESOLVED');
@@ -92,7 +92,7 @@ module('Unit | TrackedAsyncData', function () {
     test('boolean: true', async function (assert) {
       assert.expect(6);
 
-      const loadTrue = new TrackedAsyncData(true, this);
+      const loadTrue = new TrackedAsyncData(true);
       await settled();
 
       assert.strictEqual(loadTrue.state, 'RESOLVED');
@@ -106,7 +106,7 @@ module('Unit | TrackedAsyncData', function () {
     test('boolean: false', async function (assert) {
       assert.expect(6);
 
-      const loadFalse = new TrackedAsyncData(false, this);
+      const loadFalse = new TrackedAsyncData(false);
       await settled();
 
       assert.strictEqual(loadFalse.state, 'RESOLVED');
@@ -120,7 +120,7 @@ module('Unit | TrackedAsyncData', function () {
     test('number', async function (assert) {
       assert.expect(6);
 
-      const loadNumber = new TrackedAsyncData(5, this);
+      const loadNumber = new TrackedAsyncData(5);
       await settled();
 
       assert.strictEqual(loadNumber.state, 'RESOLVED');
@@ -134,7 +134,7 @@ module('Unit | TrackedAsyncData', function () {
     test('string', async function (assert) {
       assert.expect(6);
 
-      const loadString = new TrackedAsyncData('js', this);
+      const loadString = new TrackedAsyncData('js');
       await settled();
 
       // loadString
@@ -152,7 +152,7 @@ module('Unit | TrackedAsyncData', function () {
 
     // This handles the error throw from rendering a rejected promise
     const deferred = defer();
-    const result = new TrackedAsyncData(deferred.promise, this);
+    const result = new TrackedAsyncData(deferred.promise);
 
     // eslint-disable-next-line ember/no-array-prototype-extensions
     deferred.reject(new Error('foobar'));
@@ -173,7 +173,7 @@ module('Unit | TrackedAsyncData', function () {
     assert.expect(2);
 
     const deferred = defer();
-    const result = new TrackedAsyncData(deferred.promise, this);
+    const result = new TrackedAsyncData(deferred.promise);
     assert.strictEqual(result.state, 'PENDING');
 
     deferred.resolve();
@@ -186,7 +186,7 @@ module('Unit | TrackedAsyncData', function () {
     assert.expect(4);
 
     const deferred = defer();
-    const result = new TrackedAsyncData(deferred.promise, this);
+    const result = new TrackedAsyncData(deferred.promise);
     assert.strictEqual(result.state, 'PENDING');
 
     // eslint-disable-next-line ember/no-array-prototype-extensions
@@ -203,7 +203,7 @@ module('Unit | TrackedAsyncData', function () {
     assert.expect(1);
 
     const promise = Promise.resolve('hello');
-    const result = new TrackedAsyncData(promise, this);
+    const result = new TrackedAsyncData(promise);
     await promise;
     assert.strictEqual(result.state, 'RESOLVED');
   });
@@ -212,7 +212,7 @@ module('Unit | TrackedAsyncData', function () {
     assert.expect(3);
 
     const promise = Promise.reject(new Error('foobar'));
-    const result = new TrackedAsyncData(promise, this);
+    const result = new TrackedAsyncData(promise);
 
     // This handles the error thrown *locally*.
     await promise.catch((error: Error) => {


### PR DESCRIPTION
- We had a race condition with the existing waiter teardown, because of an additional, unnecessary, teardown we had in the destructor.

- Considering this also highlighted that we did not need the cache of `Promise`s to `TrackedAsyncData`. The cache had some non-trivial overhead, and it also risked leaking if anything held onto a strong reference to the `Promise`.

This is *breaking*, technically, but is a high-urgency fix so we are treating it as a bugfix.