### PR TITLE
Backport context bug fix to 0.7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ export default class Profile extends Component<{ userId: string }> {
   @service store: Store;
 
   get fullProfile() {
-    return new TrackedAsyncData(this.store.findRecord('user', userId), this);
+    return new TrackedAsyncData(this.store.findRecord('user', userId));
   }
 }
 ```
@@ -319,7 +319,7 @@ This code would invoke the getter twice on first render, which would therefore t
 This is the *correct* default behavior, even though it might be surprising at first:
 
 - For getters and templates: in Octane, caching is something we layer onto getters where it makes sense to pay for them, rather than paying for them *everywhere* (as in Ember classic) even when that's far more costly than just rerunning the getter a couple times. For API calls, it always makes sense!
-- For the `TrackedAsyncData` API, this similarly means we don't pay for extra caching of arguments in the many cases we don't need it. (We *do* guarantee we only ever have a single `TrackedAsyncData` per `Promise`, as described elsewhere in the docs, so we don't pay *more* than we need to.)
+- For the `TrackedAsyncData` API, this similarly means we don't pay for extra caching of arguments in the many cases we don't need it.
 
 _**Note:** in the future, we will make a set of [Resources](https://www.pzuraq.com/introducing-use/) layered on top of the core data types here, which will allow us to build in caching for API calls._
 
@@ -339,7 +339,7 @@ export default class SmartProfile extends Component {
 
   @cached
   get someData() {
-    return load(this.store.findRecord('user', this.args.id), this);
+    return load(this.store.findRecord('user', this.args.id));
   }
 }
 ```
@@ -593,7 +593,7 @@ The public API for `TrackedAsyncData`:
 
 ```ts
 class TrackedAsyncData<T> {
-  constructor(data: T | Promise<T>, context?: object);
+  constructor(data: T | Promise<T>);
 
   get state(): "PENDING" | "RESOLVED" | "REJECTED";
   get isPending(): boolean;
@@ -612,7 +612,6 @@ class TrackedAsyncData<T> {
 #### Notes
 
 - `value` is `T | null` today, but only for the sake of safe interop with Ember Classic computed properties (which eagerly evaluate getters for the sake of). You *should not* rely on the `null` fallback, as accessing `value` when `isResolved` is false will become a hard error at the 1.0 release. The same is true of `error`.
-- The `context` argument is currently optional but will become mandatory at the 1.0 release. This allows the type to be torn down correctly as part of Ember's "destroyables" API.
 - The class is *not* intended for subclassing, and will in fact throw in the constructor if you try to subclass it!
 - The `value` and `error` getters will *warn* if you access them and the underlying promise is in the wrong state. In the future, this will be converted to throwing an error. (It currently only warns because classic computed properties actively lookup and cache the values returned from their dependent keys.)
 
@@ -622,7 +621,7 @@ class TrackedAsyncData<T> {
 The `load` helper function is basically just a static constructor for `TrackedAsyncData`:
 
 ```ts
-function load<T>(data: T | Promise<T>, context?: object): TrackedAsyncData<T>;
+function load<T>(data: T | Promise<T>): TrackedAsyncData<T>;
 ```
 
 

--- a/ember-async-data/src/helpers/load.ts
+++ b/ember-async-data/src/helpers/load.ts
@@ -1,4 +1,4 @@
-import Helper from '@ember/component/helper';
+import { helper } from '@ember/component/helper';
 import TrackedAsyncData from '../tracked-async-data';
 
 /**
@@ -63,15 +63,16 @@ import TrackedAsyncData from '../tracked-async-data';
   @note Prefer to use `TrackedAsyncData` directly! This function is provided
     simply for symmetry with the helper and backwards compatibility.
  */
-export function load<T>(
-  data: T | Promise<T>,
-  context: {}
-): TrackedAsyncData<T> {
-  return new TrackedAsyncData(data, context);
+export function load<T>(data: T | Promise<T>): TrackedAsyncData<T> {
+  return new TrackedAsyncData(data);
 }
 
-export default class Load<T> extends Helper {
-  compute([data]: [T | Promise<T>]): TrackedAsyncData<T> {
-    return new TrackedAsyncData(data, this);
-  }
-}
+// TODO: in v2.0.0, switch this to simply using the function above. (It needs to
+// be in a breaking change because of the change in the call signature.)
+const loadHelper = helper(function loadHelper<T>([data]: [
+  T | Promise<T>
+]): TrackedAsyncData<T> {
+  return new TrackedAsyncData(data);
+});
+
+export default loadHelper;

--- a/ember-async-data/src/tracked-async-data.ts
+++ b/ember-async-data/src/tracked-async-data.ts
@@ -1,31 +1,9 @@
 import { tracked } from '@glimmer/tracking';
 import { dependentKeyCompat } from '@ember/object/compat';
-import { assert, warn } from '@ember/debug';
+import { warn } from '@ember/debug';
 import { buildWaiter } from '@ember/test-waiters';
-import {
-  associateDestroyableChild,
-  registerDestructor,
-} from '@ember/destroyable';
 
 const waiter = buildWaiter('ember-async-data');
-
-// SAFETY: we are actually *narrowing* the type here, which would *not* be safe
-// except that we uphold the invariant that a given `Promise<T>` is always
-// directly mapped to a single corresponding `TrackedAsyncData<T>` in `load`
-// below.
-//
-// This approach is roughly as if we had higher-kinded types and accordingly
-// could simply write something like `forall T : WeakMap<Promise<T>,
-// TrackedAsyncData<T>>`. Since we cannot, we provide a type-level override
-// *only* for the `get` and `set` method (the only methods we use, but also the
-// only methods for which this narrowing is relevant).
-const TRACKED_PROMISES = new WeakMap() as {
-  get<T>(key: Promise<T>): _TrackedAsyncData<T> | null;
-  set<T>(
-    key: Promise<T>,
-    value: _TrackedAsyncData<T>
-  ): WeakMap<Promise<T>, _TrackedAsyncData<T>>;
-};
 
 /** A very cheap representation of the of a promise. */
 type StateRepr<T> =
@@ -55,66 +33,32 @@ class _TrackedAsyncData<T> {
 
   /**
     @param promise The promise to load.
-    @param context The (destroyable) context to use in constructing the object.
-      An optional, but highly recommended, context object to use for managing
-      the destruction of the resulting `TrackedAsyncData`, which can be any
-      object which participates in Ember's normal destruction lifecycle
-      (components, helpers, modifiers, etc.). If you do not supply this
-      parameter, and you have a test failure which causes async code to not get
-      cleaned up you may see all following tests fail.
    */
-  constructor(data: T | Promise<T>, context: {}) {
-    assert(
-      'You must pass a destroyable object as the context for TrackedAsyncData',
-      !!context
-    );
-
+  constructor(data: T | Promise<T>) {
     if (this.constructor !== _TrackedAsyncData) {
       throw new Error('tracked-async-data cannot be subclassed');
     }
 
-    const promise = isPromiseLike(data) ? data : Promise.resolve(data);
-    this.#token = waiter.beginAsync();
-
-    // We cache a map from each `Promise` we "load" to a corresponding
-    // `TrackedAsyncData` so that if multiple callers pass in the same `Promise`,
-    // they get identical results *and* do not pay extra overhead for it. So, if
-    // we have already created a `TrackedAsyncData` for this particular promise,
-    // return it!
-    //
-    // Note that this does *not* handle the case where users passed in a value
-    // rather than a `Promise` of the value: we eagerly create a new `Promise` and
-    // therefore `TrackedAsyncData` for each of those above. This is an acceptable
-    // tradeoff because you should not normally `load` a known constant value: we
-    // support it solely to enable users to treat this similarly to `Promise`
-    // itself, so that at the site of *use*, callers can simply call` load` and
-    // trust it to do the "right thing" rather than needing to conditionally check
-    // and wrap data handed to *them*.
-    const existingTrackedAsyncData = TRACKED_PROMISES.get(promise);
-    if (existingTrackedAsyncData) {
-      return existingTrackedAsyncData;
+    if (!isPromiseLike(data)) {
+      this.#state.data = ['RESOLVED', data];
+      return;
     }
+
+    const promise = data;
+    this.#token = waiter.beginAsync();
 
     // Otherwise, we know that haven't yet handled that promise anywhere in the
     // system, so we continue creating a new instance.
-    promise
-      .then(
-        (value) => (this.#state.data = ['RESOLVED', value]),
-        (error) => (this.#state.data = ['REJECTED', error])
-      )
-      .finally(() => {
+    promise.then(
+      (value) => {
+        this.#state.data = ['RESOLVED', value];
         waiter.endAsync(this.#token);
-      });
-
-    TRACKED_PROMISES.set(promise, this);
-
-    // Handle teardown safely so that (a) we don't try to do destroyable
-    // teardown if we don't have a context and (b) if we are able to set it up,
-    // we don't leak async state!
-    associateDestroyableChild(context, this);
-    registerDestructor(this, () => {
-      waiter.endAsync(this.#token);
-    });
+      },
+      (error) => {
+        this.#state.data = ['REJECTED', error];
+        waiter.endAsync(this.#token);
+      }
+    );
   }
 
   /**
@@ -338,8 +282,7 @@ interface Rejected<T> extends _TrackedAsyncData<T> {
  */
 type TrackedAsyncData<T> = Pending<T> | Resolved<T> | Rejected<T>;
 const TrackedAsyncData = _TrackedAsyncData as new <T>(
-  data: T | Promise<T>,
-  context: {}
+  data: T | Promise<T>
 ) => TrackedAsyncData<T>;
 export default TrackedAsyncData;
 

--- a/ember-async-data/type-tests/load-test.ts
+++ b/ember-async-data/type-tests/load-test.ts
@@ -1,16 +1,23 @@
-import Helper from '@ember/component/helper';
-import TrackedAsyncData from 'ember-async-data/tracked-async-data';
-import Load, { load } from 'ember-async-data/helpers/load';
+import TrackedAsyncData from '../src/tracked-async-data';
+import loadHelper, { load } from '../src/helpers/load';
 import { expectTypeOf } from 'expect-type';
+import {
+  EmptyObject,
+  FunctionBasedHelperInstance,
+} from '@ember/component/helper';
 
 expectTypeOf(load).toEqualTypeOf<
-  <T>(data: T | Promise<T>, context: {}) => TrackedAsyncData<T>
+  <T>(data: T | Promise<T>) => TrackedAsyncData<T>
 >();
 
-expectTypeOf(load(true, {})).toEqualTypeOf(new TrackedAsyncData(true, {}));
+expectTypeOf(load(true)).toEqualTypeOf(new TrackedAsyncData(true));
 
-interface PublicAPIForHelper<T> extends Helper {
-  compute([data]: [T | Promise<T>]): TrackedAsyncData<T>;
-}
+type LoadHelper = abstract new <T>() => FunctionBasedHelperInstance<{
+  Args: {
+    Positional: [T | Promise<T>];
+    Named: EmptyObject;
+  };
+  Return: TrackedAsyncData<T>;
+}>;
 
-expectTypeOf<Load<string>>().toEqualTypeOf<PublicAPIForHelper<string>>();
+expectTypeOf(loadHelper).toEqualTypeOf<LoadHelper>();

--- a/ember-async-data/type-tests/tracked-async-data-test.ts
+++ b/ember-async-data/type-tests/tracked-async-data-test.ts
@@ -20,17 +20,17 @@ declare class PublicAPI<T> {
   toString(): string;
 }
 
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(12, {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith('hello', {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(true, {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(null, {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(undefined, {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith({ cool: 'story' }, {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(['neat'], {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve(), {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve(12), {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject(), {});
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject('gah'), {});
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(12);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith('hello');
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(true);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(null);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(undefined);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith({ cool: 'story' });
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(['neat']);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve());
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve(12));
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject());
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject('gah'));
 
 // We use `toMatchTypeOf` here to confirm the union type which makes up
 // `TrackedAsyncData` is structurally compatible with the desired public

--- a/test-app/tests/unit/helpers/load-test.ts
+++ b/test-app/tests/unit/helpers/load-test.ts
@@ -18,7 +18,7 @@ module.skip('Unit | load', function (hooks) {
 
   test('given a promise', async function (assert) {
     const { promise, resolve } = defer();
-    const result = load(promise, this);
+    const result = load(promise);
     assert.ok(
       result instanceof TrackedAsyncData,
       'it returns a TrackedAsyncData instance'
@@ -28,7 +28,7 @@ module.skip('Unit | load', function (hooks) {
   });
 
   test('given a plain value', async function (assert) {
-    const result = load(12, this);
+    const result = load(12);
     assert.ok(
       result instanceof TrackedAsyncData,
       'it returns a TrackedAsyncData instance'

--- a/test-app/tests/unit/tracked-async-data-test.ts
+++ b/test-app/tests/unit/tracked-async-data-test.ts
@@ -9,14 +9,14 @@ module('Unit | TrackedAsyncData', function () {
     //   this fails both at the type-checking level and dynamically at runtime.
     class Subclass extends TrackedAsyncData<unknown> {}
 
-    assert.throws(() => new Subclass(Promise.resolve('nope'), this));
+    assert.throws(() => new Subclass(Promise.resolve('nope')));
   });
 
   test('is initially PENDING', async function (assert) {
     assert.expect(6);
     const deferred = defer();
 
-    const result = new TrackedAsyncData(deferred.promise, this);
+    const result = new TrackedAsyncData(deferred.promise);
     assert.strictEqual(result.state, 'PENDING');
     assert.true(result.isPending);
     assert.false(result.isResolved);
@@ -32,7 +32,7 @@ module('Unit | TrackedAsyncData', function () {
     assert.expect(6);
 
     const deferred = defer();
-    const result = new TrackedAsyncData(deferred.promise, this);
+    const result = new TrackedAsyncData(deferred.promise);
 
     deferred.resolve('foobar');
     await settled();
@@ -49,7 +49,7 @@ module('Unit | TrackedAsyncData', function () {
     test('undefined', async function (assert) {
       assert.expect(6);
 
-      const loadUndefined = new TrackedAsyncData(undefined, this);
+      const loadUndefined = new TrackedAsyncData(undefined);
       await settled();
 
       assert.strictEqual(loadUndefined.state, 'RESOLVED');
@@ -63,7 +63,7 @@ module('Unit | TrackedAsyncData', function () {
     test('null', async function (assert) {
       assert.expect(6);
 
-      const loadNull = new TrackedAsyncData(null, this);
+      const loadNull = new TrackedAsyncData(null);
       await settled();
 
       assert.strictEqual(loadNull.state, 'RESOLVED');
@@ -78,7 +78,7 @@ module('Unit | TrackedAsyncData', function () {
       assert.expect(6);
 
       const notAThenableObject = { notAThenable: true };
-      const loadObject = new TrackedAsyncData(notAThenableObject, this);
+      const loadObject = new TrackedAsyncData(notAThenableObject);
       await settled();
 
       assert.strictEqual(loadObject.state, 'RESOLVED');
@@ -92,7 +92,7 @@ module('Unit | TrackedAsyncData', function () {
     test('boolean: true', async function (assert) {
       assert.expect(6);
 
-      const loadTrue = new TrackedAsyncData(true, this);
+      const loadTrue = new TrackedAsyncData(true);
       await settled();
 
       assert.strictEqual(loadTrue.state, 'RESOLVED');
@@ -106,7 +106,7 @@ module('Unit | TrackedAsyncData', function () {
     test('boolean: false', async function (assert) {
       assert.expect(6);
 
-      const loadFalse = new TrackedAsyncData(false, this);
+      const loadFalse = new TrackedAsyncData(false);
       await settled();
 
       assert.strictEqual(loadFalse.state, 'RESOLVED');
@@ -120,7 +120,7 @@ module('Unit | TrackedAsyncData', function () {
     test('number', async function (assert) {
       assert.expect(6);
 
-      const loadNumber = new TrackedAsyncData(5, this);
+      const loadNumber = new TrackedAsyncData(5);
       await settled();
 
       assert.strictEqual(loadNumber.state, 'RESOLVED');
@@ -134,7 +134,7 @@ module('Unit | TrackedAsyncData', function () {
     test('string', async function (assert) {
       assert.expect(6);
 
-      const loadString = new TrackedAsyncData('js', this);
+      const loadString = new TrackedAsyncData('js');
       await settled();
 
       // loadString
@@ -152,7 +152,7 @@ module('Unit | TrackedAsyncData', function () {
 
     // This handles the error throw from rendering a rejected promise
     const deferred = defer();
-    const result = new TrackedAsyncData(deferred.promise, this);
+    const result = new TrackedAsyncData(deferred.promise);
 
     // eslint-disable-next-line ember/no-array-prototype-extensions
     deferred.reject(new Error('foobar'));
@@ -173,7 +173,7 @@ module('Unit | TrackedAsyncData', function () {
     assert.expect(2);
 
     const deferred = defer();
-    const result = new TrackedAsyncData(deferred.promise, this);
+    const result = new TrackedAsyncData(deferred.promise);
     assert.strictEqual(result.state, 'PENDING');
 
     deferred.resolve();
@@ -186,7 +186,7 @@ module('Unit | TrackedAsyncData', function () {
     assert.expect(4);
 
     const deferred = defer();
-    const result = new TrackedAsyncData(deferred.promise, this);
+    const result = new TrackedAsyncData(deferred.promise);
     assert.strictEqual(result.state, 'PENDING');
 
     // eslint-disable-next-line ember/no-array-prototype-extensions
@@ -203,7 +203,7 @@ module('Unit | TrackedAsyncData', function () {
     assert.expect(1);
 
     const promise = Promise.resolve('hello');
-    const result = new TrackedAsyncData(promise, this);
+    const result = new TrackedAsyncData(promise);
     await promise;
     assert.strictEqual(result.state, 'RESOLVED');
   });
@@ -212,7 +212,7 @@ module('Unit | TrackedAsyncData', function () {
     assert.expect(3);
 
     const promise = Promise.reject(new Error('foobar'));
-    const result = new TrackedAsyncData(promise, this);
+    const result = new TrackedAsyncData(promise);
 
     // This handles the error thrown *locally*.
     await promise.catch((error: Error) => {


### PR DESCRIPTION
Applies the following commits from `main` to `release-0-6-x` with the relevant modifications to account for our switch to a v2 addon:

- 9dac276fe5cd6e203974342abcc3cb658f90084c
- 158c756444d5992e1e9f40778f09de1ff2b04c3d
- d6e3faa15009b15b27b778d7a523b0e195c2d254
- cd0e35840b1af863db516255c8b1379d8e2fd01d
- a14a4620d7a60e1bc242d00a839655143fde07b7
- f1850b3a699e328904d846c75e0a873705e0f814
- e5a01be803a9a99942127f83150743be2da6d4c6