### PR TITLE
Fix triple-slash reference in complied output

### DIFF
--- a/ember-async-data/src/helpers/load.ts
+++ b/ember-async-data/src/helpers/load.ts
@@ -1,4 +1,9 @@
-import { helper } from '@ember/component/helper';
+/* eslint-disable prefer-const */
+import {
+  helper,
+  type EmptyObject,
+  type FunctionBasedHelperInstance,
+} from '@ember/component/helper';
 import TrackedAsyncData from '../tracked-async-data';
 
 /**
@@ -67,9 +72,21 @@ export function load<T>(data: T | Promise<T>): TrackedAsyncData<T> {
   return new TrackedAsyncData(data);
 }
 
+type Signature<T> = {
+  Args: {
+    Positional: [T | Promise<T>];
+    Named: EmptyObject;
+  };
+  Return: TrackedAsyncData<T>;
+};
+
+let loadHelper: abstract new <T>() => FunctionBasedHelperInstance<Signature<T>>;
+
 // TODO: in v2.0.0, switch this to simply using the function above. (It needs to
 // be in a breaking change because of the change in the call signature.)
-const loadHelper = helper(function loadHelper<T>([data]: [
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+loadHelper = helper(function loadHelper<T>([data]: [
   T | Promise<T>
 ]): TrackedAsyncData<T> {
   return new TrackedAsyncData(data);


### PR DESCRIPTION
This is another attempt to fix latest published version by following suggestion in https://github.com/tracked-tools/ember-async-data/pull/704#discussion_r1309431299