### PR TITLE
Update minimum supported Ember.js version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 #### :boom: Breaking Change
 * [#527](https://github.com/tracked-tools/ember-async-data/pull/527) Drop TypeScript support for <= 4.7 ([@SergeAstapov](https://github.com/SergeAstapov))
 * [#575](https://github.com/tracked-tools/ember-async-data/pull/575) Add hard error and deprecations for 1.0 ([@chriskrycho](https://github.com/chriskrycho))
-* [#473](https://github.com/tracked-tools/ember-async-data/pull/473) Use the types published from Ember itself ([@chriskrycho](https://github.com/chriskrycho))
+* [#473](https://github.com/tracked-tools/ember-async-data/pull/473) Use the types published from Ember itself; require Ember.js v4.8.4 or above ([@chriskrycho](https://github.com/chriskrycho))
 
 #### :rocket: Enhancement
 * [#575](https://github.com/tracked-tools/ember-async-data/pull/575) Add hard error and deprecations for 1.0 ([@chriskrycho](https://github.com/chriskrycho))

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A utility/helper and data structure for representing a `Promise` in a declarativ
 
 ## Compatibility
 
-- Ember.js v3.28 or above (requires Octane Edition)
+- Ember.js v4.8.4 or above (requires Octane Edition)
 - Embroider or ember-auto-import v2.0.0 or above (this is [v2 addon](https://emberjs.github.io/rfcs/0507-embroider-v2-package-format.html)
 
 ### TypeScript


### PR DESCRIPTION
This was made as part of #473 and was part of v1.0.0 release but README.md update was missed