### PR TITLE
Update TypeScript testing matrix to include >=5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,14 @@ jobs:
       fail-fast: false
       matrix:
         ts-version:
-          - 4.7
-          - 4.8
-          - 4.9
           - 5.0
           - 5.1
+          - 5.2
+          - 5.3
+          - 5.4
+          - 5.5
+          - 5.6
+          - 5.7
           - next
 
     steps:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ A utility/helper and data structure for representing a `Promise` in a declarativ
 
 This project follows the current draft of [the Semantic Versioning for TypeScript Types][semver] proposal.
 
-- **Currently supported TypeScript versions:** v4.7 - v5.2
+- **Currently supported TypeScript versions:** v5.0 - v5.8
 - **Compiler support policy:** [simple majors][sm]
 - **Public API:** all published types not in a `-private` module are public
 


### PR DESCRIPTION
this is prerequisite for #869, as glint requires TypeScript >=4.8 and some compiled v2 addons include `.ts` extension in `import` statements which is supported since 5.0