### PR TITLE
Remove use of `inject` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ For symmetry with templates, you can also use `load` in JavaScript; it has the e
 ```ts
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { load } from 'ember-async-data';
 
 export default class SmartProfile extends Component {

--- a/ember-async-data/src/tracked-async-data.ts
+++ b/ember-async-data/src/tracked-async-data.ts
@@ -238,7 +238,7 @@ interface Rejected<T> extends _TrackedAsyncData<T> {
   ```ts
   import Component from '@glimmer/component';
   import { cached } from '@glimmer/tracking';
-  import { inject as service } from '@ember/service';
+  import { service } from '@ember/service';
   import TrackedAsyncData from 'ember-async-data/tracked-async-data';
 
   export default class SmartProfile extends Component<{ id: number }> {


### PR DESCRIPTION
`inject` is deprecated, and removing this also helps with global finding `inject` occurrences in `node_modules`.